### PR TITLE
Upgrading to golang1.12 and pinning to specific version of prometheus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10
+FROM golang:1.11
 
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go get -u github.com/prometheus/prometheus/cmd/promtool
 
@@ -6,4 +6,3 @@ FROM alpine:latest
 
 COPY --from=0 /go/bin/promtool /bin
 ENTRYPOINT ["/bin/sh"]  
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.11
+FROM golang:1.12
+ARG prom_version
+WORKDIR /tmp/build
+RUN go mod init . \
+    && GOFLAGS="-mod=vendor -mod=readonly" go get -d -v github.com/prometheus/prometheus/cmd/promtool@v${prom_version} 
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /go/bin/promtool github.com/prometheus/prometheus/cmd/promtool
 
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go get -u github.com/prometheus/prometheus/cmd/promtool
-
-FROM alpine:3.8
-
+FROM alpine:3.9
 COPY --from=0 /go/bin/promtool /bin
-CMD ["/bin/sh"]  
+ENTRYPOINT ["/bin/promtool"]  

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go get -u github.com/prometheus/promet
 FROM alpine:latest  
 
 COPY --from=0 /go/bin/promtool /bin
-ENTRYPOINT ["/bin/promtool"]  
+ENTRYPOINT ["/bin/sh"]  
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.11
 
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go get -u github.com/prometheus/prometheus/cmd/promtool
 
-FROM alpine:latest  
+FROM alpine:3.8
 
 COPY --from=0 /go/bin/promtool /bin
-ENTRYPOINT ["/bin/sh"]  
+CMD ["/bin/sh"]  

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+
+PROM_VERSION=2.9.2
+DOCKER_IMAGE=dnanexus/promtool:${PROM_VERSION}
+
+.DEFAULT_GOAL := push
+
+.PHONY: build
+build:
+	docker build --build-arg prom_version=${PROM_VERSION} -t ${DOCKER_IMAGE} .
+
+.PHONY: push
+push: build
+	docker push ${DOCKER_IMAGE} 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We built this image to be lightweight, just alpine linux with the `promtool` bin
 
 ## About this repo
 
-This repo just tracks changes to the Dockerfile.  The built image can be found at https://hub.docker.com/r/ricardoch/docker-promtool/
+This repo just tracks changes to the Dockerfile.  The built image can be found at https://hub.docker.com/r/dnanexus/promtool/
 
 ## Usage
 
@@ -21,7 +21,7 @@ Check a prometheus config file:
 ```
 docker run \
   -v /path/to/local/prometheus/configs:/tmp \
-  ricardoch/promtool:2.9.2 \
+  dnanexus/promtool:2.9.2 \
   check config /tmp/prometheus.yml
 ```
 
@@ -30,7 +30,7 @@ Check a prometheus rules file
 ```
 docker run \
   -v /path/to/local/prometheus/configs:/tmp \
-  ricardoch/promtool:2.9.2 \
+  dnanexus/promtool:2.9.2 \
   check rules /tmp/prometheus.rules.yml
 ```
 
@@ -39,7 +39,7 @@ docker run \
 ```
 pipeline:
   validate:
-    image: ricardoch/promtool:2.9.2
+    image: dnanexus/promtool:2.9.2
     commands:
       - promtool check rules prometheus.rules.yml
       - promtool check config prometheus.yml
@@ -50,7 +50,7 @@ pipeline:
 ```
 validate-prometheus-config:
   box:
-    id: ricardoch/promtool:2.9.2
+    id: dnanexus/promtool:2.9.2
   steps:
   - script:
     name: Validate prometheus configuration rules (alerting rules)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We built this image to be lightweight, just alpine linux with the `promtool` bin
 
 ## About this repo
 
-This repo just tracks changes to the Dockerfile.  The built image can be found at https://hub.docker.com/r/dnanexus/promtool/
+This repo just tracks changes to the Dockerfile.  The built image can be found at https://hub.docker.com/r/ricardoch/docker-promtool/
 
 ## Usage
 
@@ -21,7 +21,7 @@ Check a prometheus config file:
 ```
 docker run \
   -v /path/to/local/prometheus/configs:/tmp \
-  dnanexus/promtool:1.0 \
+  ricardoch/promtool:1.0 \
   check config /tmp/prometheus.yml
 ```
 
@@ -30,7 +30,7 @@ Check a prometheus rules file
 ```
 docker run \
   -v /path/to/local/prometheus/configs:/tmp \
-  dnanexus/promtool:1.0 \
+  ricardoch/promtool:1.0 \
   check rules /tmp/prometheus.rules.yml
 ```
 
@@ -39,10 +39,25 @@ docker run \
 ```
 pipeline:
   validate:
-    image: dnanexus/promtool:1.0
+    image: ricardoch/promtool:1.0
     commands:
       - promtool check rules prometheus.rules.yml
       - promtool check config prometheus.yml
+```
+
+### Using wercker pipeline step
+
+```
+validate-prometheus-config:
+  box:
+    id: ricardoch/promtool:1.0
+  steps:
+  - script:
+    name: Validate prometheus configuration rules (alerting rules)
+    description: if this is failing prometheus will not be able to start, better fail fast
+    code: |
+      promtool check config prometheus.yml
+      promtool check rules prometheus.rules.yml
 ```
 
 ## Version History

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Check a prometheus config file:
 ```
 docker run \
   -v /path/to/local/prometheus/configs:/tmp \
-  ricardoch/promtool:1.0 \
+  ricardoch/promtool:2.9.2 \
   check config /tmp/prometheus.yml
 ```
 
@@ -30,7 +30,7 @@ Check a prometheus rules file
 ```
 docker run \
   -v /path/to/local/prometheus/configs:/tmp \
-  ricardoch/promtool:1.0 \
+  ricardoch/promtool:2.9.2 \
   check rules /tmp/prometheus.rules.yml
 ```
 
@@ -39,7 +39,7 @@ docker run \
 ```
 pipeline:
   validate:
-    image: ricardoch/promtool:1.0
+    image: ricardoch/promtool:2.9.2
     commands:
       - promtool check rules prometheus.rules.yml
       - promtool check config prometheus.yml
@@ -50,7 +50,7 @@ pipeline:
 ```
 validate-prometheus-config:
   box:
-    id: ricardoch/promtool:1.0
+    id: ricardoch/promtool:2.9.2
   steps:
   - script:
     name: Validate prometheus configuration rules (alerting rules)
@@ -62,4 +62,5 @@ validate-prometheus-config:
 
 ## Version History
 
+* 2.9.2: Alignment with prometheus releases
 * 1.0: Initial release


### PR DESCRIPTION
Time for an update?

* Suggesting to upgrade to golang 1.12.x
* Pinning to the latest prometheus version
  * to achieve that, I suggest to switch to go mod... 
  * however, as a side effect, the build now takes quite long, as go get with modules support do not honor vendored modules in prometheus (but the versions)
* Bringing a Makefile to drive the build/push
* And suggesting to align the tags with the prometheus version we are consuming
  * we can do smarter things, and maintain something like: latest + 2.9.2 + 2.9.2-commitID .. up to you!
* I also kept an extra CI example from the fork where I forked, https://github.com/ricardo-ch/docker-promtool

If you are happy with this, willing to see the new version in dockerhub ;) 