### PR TITLE
Update to prometheus 2.12.0 and use alpine 3.10 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM golang:1.12
 ARG prom_version
 WORKDIR /tmp/build
 RUN go mod init . \
-    && GOFLAGS="-mod=vendor -mod=readonly" go get -d -v github.com/prometheus/prometheus/cmd/promtool@v${prom_version} 
+    && GOFLAGS="-mod=vendor -mod=readonly" go get -d -v github.com/prometheus/prometheus/cmd/promtool@v${prom_version}
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /go/bin/promtool github.com/prometheus/prometheus/cmd/promtool
 
-FROM alpine:3.9
+FROM alpine:3.10
 COPY --from=0 /go/bin/promtool /bin
-ENTRYPOINT ["/bin/promtool"]  
+ENTRYPOINT ["/bin/promtool"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-PROM_VERSION=2.9.2
+PROM_VERSION=2.12.0
 DOCKER_IMAGE=dnanexus/promtool:${PROM_VERSION}
 
 .DEFAULT_GOAL := push
@@ -10,4 +10,4 @@ build:
 
 .PHONY: push
 push: build
-	docker push ${DOCKER_IMAGE} 
+	docker push ${DOCKER_IMAGE}


### PR DESCRIPTION
I also tried to update to go 1.13 but it seems to have an issue (might be related to https://github.com/golang/go/issues/33807).

I built the new image and tested against a sample alerting rule configuration file.