### PR TITLE
fix: Don't use go tooling to build / use latest promtool 2.18.1 + go1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM golang:1.12
+FROM golang:1.14
 ARG prom_version
 WORKDIR /tmp/build
-RUN go mod init . \
-    && GOFLAGS="-mod=vendor -mod=readonly" go get -d -v github.com/prometheus/prometheus/cmd/promtool@v${prom_version} 
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /go/bin/promtool github.com/prometheus/prometheus/cmd/promtool
-
-FROM alpine:3.9
-COPY --from=0 /go/bin/promtool /bin
-ENTRYPOINT ["/bin/promtool"]  
+RUN git clone https://github.com/prometheus/prometheus --branch v${prom_version} --single-branch --depth 1 && \
+    cd prometheus && \
+    PROMU_BINARIES=promtool make common-build
+FROM alpine:3.11.6
+COPY --from=0 /tmp/build/prometheus/promtool /bin
+ENTRYPOINT ["/bin/promtool"]


### PR DESCRIPTION
https://hub.docker.com/repository/docker/aeronotix/promtool